### PR TITLE
mk_*arena, default alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - name: no_default_features
       os: linux
       rust: stable
-      script: 
+      script:
         - cargo test --no-default-features
         - cargo test --release --no-default-features
 
@@ -29,12 +29,19 @@ matrix:
         - cargo test --no-default-features --features uninit
         - cargo test --release --no-default-features --features uninit
 
+    - name: all_features
+      os: linux
+      rust: stable
+      script:
+        - cargo test --all-features
+        - cargo test --release --all-features
+
     - name: clippy
       os: linux
       rust: stable
       install:
         - rustup component add clippy
-      script: 
+      script:
         - cargo clippy --verbose --all --tests
         - cargo clippy --verbose --all --tests --no-default-features
         - cargo clippy --verbose --all --tests --no-default-features --features uninit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2018"
 keywords = ["arena"]
 license = "MIT OR Apache-2.0"
 name = "compact_arena"
-version = "0.2.1"
+version = "0.3.0"
 repository = "https://github.com/llogiq/compact_arena"
 categories = ["memory-management"]
 
 [features]
 uninit = []
+alloc = []
+default = ["alloc"]


### PR DESCRIPTION
This introduces a default "alloc" feature without which this crate is `no_std` compatible. This fixes #1.

Also the length fields have been extended so that a `TinyArena` now allows for 65536 elements and a `NanoArena` for 256 elements. Finally all arenas now have `mk_*arena!` macros that can be used directly without needing to introduce a new scope.

The version has been updated to 0.3.0.