### PR TITLE
add compile tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["memory-management"]
 uninit = []
 alloc = []
 default = ["alloc"]
+
+[dev-dependencies]
+compiletest_rs = { version = "*", features = [ "stable" ] }

--- a/tests/nano_arena.rs
+++ b/tests/nano_arena.rs
@@ -20,3 +20,14 @@ fn add_257_objects() {
         arena.add(257); // should panic
     });
 }
+
+#[test]
+fn two_nano_arenas() {
+    assert_eq!(3, in_nano_arena!(a, {
+        in_nano_arena!(b, {
+            let x = a.add(1usize);
+            let y = b.add(2usize);
+            a[x] + b[y]
+        })
+    }));
+}

--- a/tests/tiny_arena.rs
+++ b/tests/tiny_arena.rs
@@ -1,9 +1,8 @@
+use compact_arena::in_tiny_arena;
 
 #[cfg(not(miri))] // this will take too much time for miri
 #[test]
 fn add_65536_objects() {
-    use compact_arena::in_tiny_arena;
-
     in_tiny_arena!(arena, {
         for _ in 0..=65535 {
             arena.add(42); // all should be ok
@@ -15,12 +14,21 @@ fn add_65536_objects() {
 #[test]
 #[should_panic(expected = "Capacity Exceeded")]
 fn add_65537_objects() {
-    use compact_arena::in_tiny_arena;
-
     in_tiny_arena!(arena, {
         for _ in 0..=65535 {
             arena.add(42); // all should be ok
         }
         arena.add(65537); // should panic
     });
+}
+
+#[test]
+fn two_tiny_arenas() {
+    assert_eq!(3, in_tiny_arena!(a, {
+        in_tiny_arena!(b, {
+            let x = a.add(1usize);
+            let y = b.add(2usize);
+            a[x] + b[y]
+        })
+    }));
 }

--- a/tests/ui/mixup.rs
+++ b/tests/ui/mixup.rs
@@ -1,0 +1,14 @@
+extern crate compact_arena;
+
+use compact_arena::in_nano_arena;
+
+fn main() {
+    in_nano_arena!(a, {
+        in_nano_arena!(b, {
+            let _ = a.add(1usize);
+            let x = a.add(1usize);
+            let y = b.add(1usize);
+            let _ = b[x];
+        })
+    });
+}

--- a/tests/ui/mixup.stderr
+++ b/tests/ui/mixup.stderr
@@ -1,0 +1,25 @@
+error[E0597]: `tag` does not live long enough
+  --> $DIR/mixup.rs:7:9
+   |
+6  |   /     in_nano_arena!(a, {
+7  |   |         in_nano_arena!(b, {
+   |   |_________^
+   |  ||_________|
+   | |||
+8  | |||             let _ = a.add(1usize);
+9  | |||             let x = a.add(1usize);
+10 | |||             let y = b.add(1usize);
+11 | |||             let _ = b[x];
+12 | |||         })
+   | |||          ^
+   | |||__________|
+   | |_|__________borrowed value does not live long enough
+   |   |          `tag` dropped here while still borrowed
+13 |   |     });
+   |   |_______- borrowed value needs to live until here
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/recurse.rs
+++ b/tests/ui/recurse.rs
@@ -1,0 +1,16 @@
+extern crate compact_arena;
+
+use compact_arena::{mk_nano_arena, Idx8};
+
+fn recursive(idx: Option<Idx8<'_>>) {
+    mk_nano_arena!(arena); // `tag` does not live long enough
+    if let Some(idx) = idx {
+        assert_eq!("hello", arena[idx]);
+    } else {
+        recursive(Some(arena.add("hello")));
+    }
+}
+
+fn main() {
+    recursive(None);
+}

--- a/tests/ui/recurse.stderr
+++ b/tests/ui/recurse.stderr
@@ -1,0 +1,25 @@
+error[E0597]: `tag` does not live long enough
+  --> $DIR/recurse.rs:6:5
+   |
+6  |     mk_nano_arena!(arena); // `tag` does not live long enough
+   |     ^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+...
+12 | }
+   | - borrowed value only lives until here
+   |
+note: borrowed value must be valid for the anonymous lifetime #1 defined on the function body at 5:1...
+  --> $DIR/recurse.rs:5:1
+   |
+5  | / fn recursive(idx: Option<Idx8<'_>>) {
+6  | |     mk_nano_arena!(arena); // `tag` does not live long enough
+7  | |     if let Some(idx) = idx {
+8  | |         assert_eq!("hello", arena[idx]);
+...  |
+11 | |     }
+12 | | }
+   | |_^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/threads.rs
+++ b/tests/ui/threads.rs
@@ -1,0 +1,21 @@
+extern crate compact_arena;
+
+use std::{thread, sync::mpsc::{channel, Receiver, Sender}};
+use compact_arena::{mk_tiny_arena, Idx16};
+
+fn mixup(s: Option<Sender<Idx16<'_>>>, r: Option<Receiver<Idx16<'_>>>) {
+    mk_tiny_arena!(arena);
+    match (s, r) {
+        (Some(s), None) => s.send(arena.add(1usize)).unwrap(),
+        (None, Some(r)) => assert_eq!(1, arena[r.recv().unwrap()]),
+        _ => unreachable!()
+    }
+}
+
+fn main() {
+    let (s, r) = channel();
+    let st = thread::spawn(|| mixup(Some(s), None));
+    let rt = thread::spawn(|| mixup(None, Some(r)));
+    st.join().unwrap();
+    rt.join().unwrap();
+}

--- a/tests/ui/threads.stderr
+++ b/tests/ui/threads.stderr
@@ -1,0 +1,12 @@
+error[E0623]: lifetime mismatch
+ --> $DIR/threads.rs:9:35
+  |
+6 | fn mixup(s: Option<Sender<Idx16<'_>>>, r: Option<Receiver<Idx16<'_>>>) {
+  |                           ---------                       --------- these two types are declared with different lifetimes...
+...
+9 |         (Some(s), None) => s.send(arena.add(1usize)).unwrap(),
+  |                                   ^^^^^^^^^^^^^^^^^ ...but data from `r` flows into `s` here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -1,0 +1,14 @@
+use compiletest_rs::{Config, run_tests};
+
+#[test]
+pub fn run_ui_tests() {
+    let mut config = Config {
+        mode: "ui".parse().expect("Invalid mode"),
+        src_base: "tests/ui".into(),
+        build_base: "target/debug/ui_tests".into(),
+        ..Config::default()
+    };
+    config.link_deps();
+    config.clean_rmeta();
+    run_tests(&config);
+}


### PR DESCRIPTION
This adds a number of compile tests to ensure that "wrong" usage patterns actually get caught. Also adds a test for some known good usages (e.g. using two arenas without mixing them up).