### PR TITLE
Use generativity to ensure soundness even with NLL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "compact_arena"
 readme = "README.md"
 repository = "https://github.com/llogiq/compact_arena"
-version = "0.3.1"
+version = "0.3.2"
 
 [badges]
 travis-ci = { repository = "llogiq/compact_arena" }

--- a/tests/threads.rs
+++ b/tests/threads.rs
@@ -5,7 +5,8 @@ use crossbeam_utils::thread::scope;
 
 // With crossbeam's `scope`d threads, it is even possible to share an arena
 // and its indices between multiple threads.
-fn main() {
+#[test]
+fn test_scoped_arena() {
     mk_nano_arena!(arena);
     let i = arena.add(1usize);
     let v = scope(|s| {

--- a/tests/ui/mixup.stderr
+++ b/tests/ui/mixup.stderr
@@ -3,16 +3,14 @@ error[E0597]: `tag` does not live long enough
    |
 6  |   /     in_nano_arena!(a, {
 7  |   |         in_nano_arena!(b, {
-   |   |_________^
-   |  ||_________|
-   | |||
-8  | |||             let _ = a.add(1usize);
-9  | |||             let x = a.add(1usize);
-10 | |||             let y = b.add(1usize);
-11 | |||             let _ = b[x];
-12 | |||         })
-   | |||          ^
-   | |||__________|
+   |  _|_________^
+8  | | |             let _ = a.add(1usize);
+9  | | |             let x = a.add(1usize);
+10 | | |             let y = b.add(1usize);
+11 | | |             let _ = b[x];
+12 | | |         })
+   | | |          ^
+   | | |          |
    | |_|__________borrowed value does not live long enough
    |   |          `tag` dropped here while still borrowed
 13 |   |     });


### PR DESCRIPTION
It was recently found out that edition 2018 NLL doesn't ensure lifetime uniqueness with the current setup. This uses a slightly different scheme, which unfortunately makes `InvariantLifetime`part of the public API, but that's a small price to pay for soundness.

This fixes #22 