### PR TITLE
fmt and extended docs

### DIFF
--- a/tests/nano_arena.rs
+++ b/tests/nano_arena.rs
@@ -23,13 +23,16 @@ fn add_257_objects() {
 
 #[test]
 fn two_nano_arenas() {
-    assert_eq!(3, in_nano_arena!(a, {
-        in_nano_arena!(b, {
-            let x = a.add(1usize);
-            let y = b.add(2usize);
-            a[x] + b[y]
+    assert_eq!(
+        3,
+        in_nano_arena!(a, {
+            in_nano_arena!(b, {
+                let x = a.add(1usize);
+                let y = b.add(2usize);
+                a[x] + b[y]
+            })
         })
-    }));
+    );
 }
 
 #[test]

--- a/tests/threads.rs
+++ b/tests/threads.rs
@@ -17,6 +17,7 @@ fn test_scoped_arena() {
         });
         // join it, receiving a new index from the thread
         t.join().unwrap()
-    }).unwrap();
+    })
+    .unwrap();
     assert_eq!(2, arena[v]);
 }

--- a/tests/tiny_arena.rs
+++ b/tests/tiny_arena.rs
@@ -24,24 +24,37 @@ fn add_65537_objects() {
 
 #[test]
 fn two_tiny_arenas() {
-    std::thread::Builder::new().stack_size(32 * 1024 * 1024).spawn(|| {
-        assert_eq!(3, in_tiny_arena!(a, {
-            in_tiny_arena!(b, {
-                let x = a.add(1usize);
-                let y = b.add(2usize);
-                a[x] + b[y]
-            })
-        }))
-    }).unwrap().join().unwrap();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            assert_eq!(
+                3,
+                in_tiny_arena!(a, {
+                    in_tiny_arena!(b, {
+                        let x = a.add(1usize);
+                        let y = b.add(2usize);
+                        a[x] + b[y]
+                    })
+                })
+            )
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }
 
 #[test]
 fn two_tiny_arenas_one_scope() {
-    std::thread::Builder::new().stack_size(32 * 1024 * 1024).spawn(|| {
-        mk_tiny_arena!(a);
-        mk_tiny_arena!(b);
-        let x = a.add(1usize);
-        let y = b.add(2usize);
-        assert_eq!(3, a[x] + b[y])
-    }).unwrap().join().unwrap();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            mk_tiny_arena!(a);
+            mk_tiny_arena!(b);
+            let x = a.add(1usize);
+            let y = b.add(2usize);
+            assert_eq!(3, a[x] + b[y])
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,14 +1,13 @@
 #[cfg(feature = "alloc")]
-use compact_arena::{SmallArena as Arena, mk_arena, Idx32 as Idx};
+use compact_arena::{mk_arena, Idx32 as Idx, SmallArena as Arena};
 
 #[cfg(not(feature = "alloc"))]
-use compact_arena::{NanoArena as Arena, mk_nano_arena as mk_arena, Idx8 as Idx};
+use compact_arena::{mk_nano_arena as mk_arena, Idx8 as Idx, NanoArena as Arena};
 
 #[derive(Default, Copy, Clone)]
 struct Tree<'tag>(Option<(Idx<'tag>, Idx<'tag>)>);
 
-fn top_down_tree<'tag>(arena: &mut Arena<'tag, Tree<'tag>>, d: usize)
--> Idx<'tag> {
+fn top_down_tree<'tag>(arena: &mut Arena<'tag, Tree<'tag>>, d: usize) -> Idx<'tag> {
     let children = if d > 0 {
         Some((top_down_tree(arena, d - 1), top_down_tree(arena, d - 1)))
     } else {
@@ -17,8 +16,7 @@ fn top_down_tree<'tag>(arena: &mut Arena<'tag, Tree<'tag>>, d: usize)
     arena.add(Tree(children))
 }
 
-fn bottom_up_tree<'tag>(arena: &mut Arena<'tag, Tree<'tag>>, depth: usize)
--> Idx<'tag> {
+fn bottom_up_tree<'tag>(arena: &mut Arena<'tag, Tree<'tag>>, depth: usize) -> Idx<'tag> {
     let i = arena.add(Tree(None));
     if depth > 0 {
         let d = depth - 1;

--- a/tests/ui_tests.rs
+++ b/tests/ui_tests.rs
@@ -1,4 +1,4 @@
-use compiletest_rs::{Config, run_tests};
+use compiletest_rs::{run_tests, Config};
 
 #[test]
 pub fn run_ui_tests() {


### PR DESCRIPTION
Looking into the recycle implementation for `TinyArena` and `NanoArena`, I found that since they store the elements inline, recycling gets no benefit compared to just re-creating the arenas. So I at least documented that fact and ran cargo fmt on the code.